### PR TITLE
Align WPF with API and provide manual OpenAPI

### DIFF
--- a/Api/Api.csproj
+++ b/Api/Api.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.18" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
@@ -22,5 +20,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+
 
 </Project>

--- a/Api/Program.cs
+++ b/Api/Program.cs
@@ -22,16 +22,11 @@ else
     builder.Services.AddSingleton<IUserDataService>(_ => new JsonUserDataService(jsonFile));
 }
 
-builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
-
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.UseSwagger();
-    app.UseSwaggerUI();
-}
+// Serve static OpenAPI definition and UI
+app.UseDefaultFiles();
+app.UseStaticFiles();
 
 app.MapPost("/login", async (IUserDataService svc, UserModel creds) =>
 {

--- a/Api/wwwroot/index.html
+++ b/Api/wwwroot/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Login API</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.9.0/swagger-ui.css" integrity="sha512-+dIOqN1CLRtVlpNzc10uAlbKDVlZG9hVSa5YKAGX4OojmcGxDFkhhjYUz7DtwKgOEy3TsC4+k9P0LAbB4Q6+xg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+</head>
+<body>
+    <div id="swagger-ui"></div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.9.0/swagger-ui-bundle.js" integrity="sha512-1OCatgGYG+ZwFsS3iMSXl7j+8I38bYT2v76sFPaYtulrSczXGr0C+MEY0S8mV+4CSkiUbSSjMBDuNIQP5CKVYQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+        window.onload = () => {
+            SwaggerUIBundle({
+                url: 'swagger.json',
+                dom_id: '#swagger-ui'
+            });
+        };
+    </script>
+</body>
+</html>

--- a/Api/wwwroot/swagger.json
+++ b/Api/wwwroot/swagger.json
@@ -1,0 +1,172 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Login API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/login": {
+      "post": {
+        "summary": "Verify login credentials",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Login result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "summary": "Get all users",
+        "responses": {
+          "200": {
+            "description": "List of users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/UserModel" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add new user",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserModel" }
+            }
+          }
+        },
+        "responses": {
+          "201": { "description": "User created" },
+          "409": { "description": "User exists" }
+        }
+      }
+    },
+    "/users/{username}": {
+      "get": {
+        "summary": "Get user by username",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserModel" }
+              }
+            }
+          },
+          "404": { "description": "Not found" }
+        }
+      },
+      "delete": {
+        "summary": "Delete user",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Deleted" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/users/{id}": {
+      "put": {
+        "summary": "Update user",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/UserModel" }
+            }
+          }
+        },
+        "responses": {
+          "200": { "description": "Updated" },
+          "404": { "description": "Not found" }
+        }
+      }
+    },
+    "/users/{id}/description": {
+      "put": {
+        "summary": "Update description",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "description",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": { "description": "Updated" },
+          "404": { "description": "Not found" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "UserModel": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "username": { "type": "string" },
+          "password": { "type": "string" },
+          "description": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cd Api
 dotnet run
 ```
 
-When running in development the API serves Swagger UI at `http://localhost:5000/swagger`.
+When running, the API serves a static OpenAPI document with Swagger UI at `http://localhost:5000/`.
 
 ## Available Endpoints
 

--- a/test/App.xaml.cs
+++ b/test/App.xaml.cs
@@ -23,6 +23,7 @@ namespace test
 
             string storage = config["AppSettings:Storage"] ?? "Json";
             string connStr = config["AppSettings:ConnectionString"] ?? string.Empty;
+            string apiBase = config["AppSettings:ApiBaseUrl"] ?? "http://localhost:5000";
             string jsonFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Data", "user.json");
 
             // 2. If SQL is requested, try to migrate JSON → SQL first
@@ -67,6 +68,11 @@ namespace test
             {
                 services.AddSingleton<IUserDataService>(
                     _ => new SqlUserDataService(connStr));
+            }
+            else if (storage.Equals("Api", StringComparison.OrdinalIgnoreCase))
+            {
+                services.AddSingleton<IUserDataService>(
+                    _ => new ApiUserDataService(apiBase));
             }
             else
             {

--- a/test/DataAccess/ApiUserDataService.cs
+++ b/test/DataAccess/ApiUserDataService.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using test.Models;
+using test.Services;
+
+namespace test.DataAccess
+{
+    public class ApiUserDataService : IUserDataService
+    {
+        private readonly HttpClient _client;
+
+        public ApiUserDataService(string baseUrl)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+                throw new ArgumentException("Base URL required", nameof(baseUrl));
+
+            _client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        }
+
+        public async Task<bool> AddUserAsync(UserModel user)
+        {
+            var response = await _client.PostAsJsonAsync("/users", user);
+            return response.IsSuccessStatusCode;
+        }
+
+        public async Task<bool> DeleteUserAsync(string username)
+        {
+            var response = await _client.DeleteAsync($"/users/{Uri.EscapeDataString(username)}");
+            return response.IsSuccessStatusCode;
+        }
+
+        public async Task<bool> UpdateUserAsync(UserModel user)
+        {
+            var response = await _client.PutAsJsonAsync($"/users/{user.Id}", user);
+            return response.IsSuccessStatusCode;
+        }
+
+        public async Task<List<UserModel>> GetAllUsersAsync()
+        {
+            var users = await _client.GetFromJsonAsync<List<UserModel>>("/users");
+            return users ?? new List<UserModel>();
+        }
+
+        public async Task<UserModel?> GetUserAsync(string username)
+        {
+            return await _client.GetFromJsonAsync<UserModel>($"/users/{Uri.EscapeDataString(username)}");
+        }
+
+        public async Task<bool> UserExistsAsync(string username)
+        {
+            return await GetUserAsync(username) != null;
+        }
+
+        public async Task<bool> VerifyUserPasswordAsync(string username, string password)
+        {
+            var response = await _client.PostAsJsonAsync("/login", new UserModel { Username = username, Password = password });
+            if (!response.IsSuccessStatusCode) return false;
+            var result = await response.Content.ReadFromJsonAsync<LoginResult>();
+            return result?.success ?? false;
+        }
+
+        public async Task<bool> UpdateUserDescriptionAsync(int id, string description)
+        {
+            var response = await _client.PutAsync($"/users/{id}/description?description={Uri.EscapeDataString(description)}", null);
+            return response.IsSuccessStatusCode;
+        }
+
+        private record LoginResult(bool success);
+    }
+}

--- a/test/appsettings.json
+++ b/test/appsettings.json
@@ -1,6 +1,7 @@
-﻿{
+{
   "AppSettings": {
-    "Storage": "Sql",
-    "ConnectionString": "Server=.\\maxidata;Database=UserAuthDB;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=True;"
+    "Storage": "Api",
+    "ConnectionString": "Server=.\\maxidata;Database=UserAuthDB;Trusted_Connection=True;Encrypt=True;TrustServerCertificate=True;",
+    "ApiBaseUrl": "http://localhost:5000"
   }
 }

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -14,11 +14,14 @@
 		<!-- Dependency Injection container -->
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 
-		<!-- ADO.NET SQL client -->
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />
+                <!-- ADO.NET SQL client -->
+                <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.3" />
 
-		<!-- JSON serialization – upgraded to pick up latest security patches -->
-		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+                <!-- JSON serialization – upgraded to pick up latest security patches -->
+                <PackageReference Include="System.Text.Json" Version="8.0.5" />
+
+                <!-- HTTP + JSON helpers for calling the Web API -->
+                <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
 
 		<!-- BCrypt password hashing -->
 		<PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />


### PR DESCRIPTION
## Summary
- replace auto-generated Swagger with static OpenAPI spec and UI
- add Http-based IUserDataService for WPF to call the web API
- wire up API-based storage option in WPF configuration

## Testing
- `dotnet build Api/Api.csproj`
- `dotnet build test/test.csproj` *(fails: Microsoft.NET.Sdk.WindowsDesktop targets not found)*

